### PR TITLE
Modify placement of some text amplifier fields for land and subsurface units

### DIFF
--- a/instance/jmsml_D_Base.xml
+++ b/instance/jmsml_D_Base.xml
@@ -603,6 +603,7 @@
         <Field Name="H" Label="Additional Information" AmplifierID="H" X="1" Y="-2"/>
         <Field Name="T" Label="Unique Designation (Track Number)" Description="A text amplifier for units, equipment, and installations that uniquely identifies a particular symbol or track number." Remarks="Prefix = TN:#####  Example: TN:13579" AmplifierID="T" X="1" Y="2"/>
         <Field Name="V" Label="Type" Description="A text amplifier for equipment that indicates types of equipment." AmplifierID="V" X="1" Y="1"/>
+        <Field Name="X" Label="Depth" Description="A text amplifier for equipment that displays depth for submerged objects." AmplifierID="X" X="1" Y="0"/>
       </Fields>
       <SymbolSets>
         <SymbolSetRef ID="SS_SEA_SUBSURFACE" Label="Sea Subsurface" Instance="jmsml_D_Sea_Subsurface.xml">


### PR DESCRIPTION
While browsing the latest [2525D spec.](http://www.assistdocs.com/search/document_details.cfm?ident_number=114934) I noticed that a couple of inconsistencies between the placement of amplifier fields in the PDF and `jmsml_D_Base.xml` . This pull request attempts to correct this for the land (page 183/167 in the spec.) and subsurface units (page 346/330). 

![image](https://cloud.githubusercontent.com/assets/29217/4564294/26d71786-4f16-11e4-9cab-ebcdeff53830.png)
![image](https://cloud.githubusercontent.com/assets/29217/4564298/33ae9d80-4f16-11e4-902e-a182c639f2b9.png)
