### PR TITLE
Add missing mod1 00 to land equipment. Fix color to black for 10751.svg

### DIFF
--- a/instance/jmsml_D_Land_Equipment.xml
+++ b/instance/jmsml_D_Land_Equipment.xml
@@ -1433,6 +1433,12 @@
     </Entity>
   </Entities>
   <SectorOneModifiers>
+    <Modifier ID="NA" Label="Not Applicable"  Category="NA" Standard="MILSTD_2525">
+      <ModifierCode>
+        <DigitOne>0</DigitOne>
+        <DigitTwo>0</DigitTwo>
+      </ModifierCode>
+    </Modifier>
     <Modifier ID="BIOLOGICAL_MOD" Label="Biological" Graphic="15011.svg" Category="Sensor Type">
       <ModifierCode>
         <DigitOne>0</DigitOne>

--- a/svg/MIL_STD_2525D_Symbols/Appendices/Land/mod1/10751.svg
+++ b/svg/MIL_STD_2525D_Symbols/Appendices/Land/mod1/10751.svg
@@ -20,7 +20,7 @@
 	</g>
 </g>
 <g id="mod1">
-	<line fill="none" stroke="#0000FF" stroke-width="25" x1="274.224" y1="315.643" x2="340.416" y2="315.643"/>
-	<line fill="none" stroke="#0000FF" stroke-width="25" x1="307.319" y1="280.793" x2="307.319" y2="346.985"/>
+	<line fill="none" stroke="#000000" stroke-width="25" x1="274.224" y1="315.643" x2="340.416" y2="315.643"/>
+	<line fill="none" stroke="#000000" stroke-width="25" x1="307.319" y1="280.793" x2="307.319" y2="346.985"/>
 </g>
 </svg>


### PR DESCRIPTION
1) Land Equipment does not have a reference to "Not Applicable" SectorOne Modifier ("00"). This change adds this so tools can display this for drop downs, etc.

2) 10751.svg used a blue color to display the SectorOne Modifier (medical cross). This change makes it black.


Jack