### PR TITLE
Removed special land unit entitites from domain exports

### DIFF
--- a/samples/name_domains_values/All_Coded_Domain_Values.csv
+++ b/samples/name_domains_values/All_Coded_Domain_Values.csv
@@ -282,10 +282,6 @@ Law Enforcement (Land Units) : TSA,201000
 Law Enforcement (Land Units) : Coast Guard,201100
 Law Enforcement (Land Units) : US Marshals Service,201200
 Law Enforcement (Land Units) : Internal Security Force,201300
-Special Entity Subtypes : Headquarters Element,XXXX95
-Special Entity Subtypes : Division and Below Support,XXXX96
-Special Entity Subtypes : Corps Support,XXXX97
-Special Entity Subtypes : Theater/Echelons Above Corps Support,XXXX98
 Unspecified,000000
 Civilian (Land Civilian),110000
 Civilian (Land Civilian) : Environmental Protection,110100

--- a/samples/name_domains_values/All_Coded_Domain_Values_Entities.csv
+++ b/samples/name_domains_values/All_Coded_Domain_Values_Entities.csv
@@ -282,10 +282,6 @@ Law Enforcement (Land Units) : TSA,201000
 Law Enforcement (Land Units) : Coast Guard,201100
 Law Enforcement (Land Units) : US Marshals Service,201200
 Law Enforcement (Land Units) : Internal Security Force,201300
-Special Entity Subtypes : Headquarters Element,XXXX95
-Special Entity Subtypes : Division and Below Support,XXXX96
-Special Entity Subtypes : Corps Support,XXXX97
-Special Entity Subtypes : Theater/Echelons Above Corps Support,XXXX98
 Unspecified,000000
 Civilian (Land Civilian),110000
 Civilian (Land Civilian) : Environmental Protection,110100

--- a/samples/name_domains_values/Coded_Domain_Land_Unit_Entities.csv
+++ b/samples/name_domains_values/Coded_Domain_Land_Unit_Entities.csv
@@ -191,7 +191,3 @@ Law Enforcement (Land Units) : TSA,201000
 Law Enforcement (Land Units) : Coast Guard,201100
 Law Enforcement (Land Units) : US Marshals Service,201200
 Law Enforcement (Land Units) : Internal Security Force,201300
-Special Entity Subtypes : Headquarters Element,XXXX95
-Special Entity Subtypes : Division and Below Support,XXXX96
-Special Entity Subtypes : Corps Support,XXXX97
-Special Entity Subtypes : Theater/Echelons Above Corps Support,XXXX98

--- a/source/JointMilitarySymbologyLibraryCS/etl.cs
+++ b/source/JointMilitarySymbologyLibraryCS/etl.cs
@@ -186,7 +186,7 @@ namespace JointMilitarySymbologyLibrary
 
                     // Now process through any special entity sub types that might exist in a symbol set
 
-                    if (s.SpecialEntitySubTypes != null)
+                    if (s.SpecialEntitySubTypes != null && !(exporter is DomainEntityExport))
                     {
                         foreach (EntitySubTypeType eSubType in s.SpecialEntitySubTypes)
                         {


### PR DESCRIPTION
While we use these special entities in our image name category tag
export files, we don't need them in our domain range exports.