### PR TITLE
Schema.ini to force short domain values

### DIFF
--- a/samples/name_domains_values/Schema.ini
+++ b/samples/name_domains_values/Schema.ini
@@ -1,0 +1,11 @@
+[Coded_Domain_Credibility.csv]
+Format=CSVDelimited
+ColNameHeader=True
+Col1=Name Text
+Col2=Value Short
+
+[Coded_Domain_TrueFalse.csv]
+Format=CSVDelimited
+ColNameHeader=True
+Col1=Name Text
+Col2=Value Short


### PR DESCRIPTION
The TrueFalse and Credibility are short domains in the current mil
feature GDB schema.  Entries in this Schema.ini file force the
TableToDomain GP tool in arcpy to treat these two domains correctly.