### PR TITLE
Embedded comma quote logic change

### DIFF
--- a/samples/name_domains_values/Coded_Domain_CombatEffectiveness.csv
+++ b/samples/name_domains_values/Coded_Domain_CombatEffectiveness.csv
@@ -1,6 +1,6 @@
 Name,Value
-"Fully Operational",FO
-"Substantially Operational",SO
-"Marginally Operational",MO
-"Not Operational",NO
-"Unknown",UNK
+Fully Operational,FO
+Substantially Operational,SO
+Marginally Operational,MO
+Not Operational,NO
+Unknown,UNK

--- a/samples/name_domains_values/Coded_Domain_CountryCodes.csv
+++ b/samples/name_domains_values/Coded_Domain_CountryCodes.csv
@@ -1,281 +1,281 @@
 Name,Value
-"Afghanistan",AFG
-"Akrotiri",XQZ
-"Albania",ALB
-"Algeria",DZA
-"American Samoa",ASM
-"Andorra",AND
-"Angola",AGO
-"Anguilla",AIA
-"Antarctica",ATA
-"Antigua and Barbuda",ATG
-"Argentina",ARG
-"Armenia",ARM
-"Aruba",ABW
-"Ashmore and Cartier Islands",XAC
-"Australia",AUS
-"Austria",AUT
-"Azerbaijan",AZE
+Afghanistan,AFG
+Akrotiri,XQZ
+Albania,ALB
+Algeria,DZA
+American Samoa,ASM
+Andorra,AND
+Angola,AGO
+Anguilla,AIA
+Antarctica,ATA
+Antigua and Barbuda,ATG
+Argentina,ARG
+Armenia,ARM
+Aruba,ABW
+Ashmore and Cartier Islands,XAC
+Australia,AUS
+Austria,AUT
+Azerbaijan,AZE
 "Bahamas, The",BHS
-"Bahrain",BHR
-"Baker Island",XBK
-"Bangladesh",BGD
-"Barbados",BRB
-"Bassas Da India",XBI
-"Belarus",BLR
-"Belgium",BEL
-"Belize",BLZ
-"Benin",BEN
-"Bermuda",BMU
-"Bhutan",BTN
-"Bolivia",BOL
+Bahrain,BHR
+Baker Island,XBK
+Bangladesh,BGD
+Barbados,BRB
+Bassas Da India,XBI
+Belarus,BLR
+Belgium,BEL
+Belize,BLZ
+Benin,BEN
+Bermuda,BMU
+Bhutan,BTN
+Bolivia,BOL
 "Bonaire, Sint Eustatius, and Saba",BES
-"Bosnia and Herzegovina",BIH
-"Botswana",BWA
-"Bouvet Island",BVT
-"Brazil",BRA
-"British Indian Ocean Territory",IOT
-"Brunei",BRN
-"Bulgaria",BGR
-"Burkina Faso",BFA
-"Burma",MMR
-"Burundi",BDI
-"Cabo Verde",CPV
-"Cambodia",KHM
-"Cameroon",CMR
-"Canada",CAN
-"Cayman Islands",CYM
-"Central African Republic",CAF
-"Chad",TCD
-"Chile",CHL
-"China",CHN
-"Christmas Island",CXR
-"Clipperton Island",CPT
-"Cocos (Keeling) Islands",CCK
-"Colombia",COL
-"Comoros",COM
-"Congo (Brazzaville)",COG
-"Congo (Kinshasa)",COD
-"Cook Islands",COK
-"Coral Sea Islands",XCS
-"Costa Rica",CRI
-"Côte d’Ivoire",CIV
-"Croatia",HRV
-"Cuba",CUB
-"Curaçao",CUW
-"Cyprus",CYP
-"Czech Republic",CZE
-"Denmark",DNK
-"Dhekelia",XXD
-"Diego Garcia",DGA
-"Djibouti",DJI
-"Dominica",DMA
-"Dominican Republic",DOM
-"Ecuador",ECU
-"Egypt",EGY
-"El Salvador",SLV
-"Entity 1",XAZ
-"Entity 2",XCR
-"Entity 3",XCY
-"Entity 4",XKM
-"Entity 5",XKN
-"Entity 6",AX3
-"Equatorial Guinea",GNQ
-"Eritrea",ERI
-"Estonia",EST
-"Ethiopia",ETH
-"Europa Island",XEU
-"Falkland Islands (Islas Malvinas)",FLK
-"Faroe Islands",FRO
-"Fiji",FJI
-"Finland",FIN
-"France",FRA
-"French Guiana",GUF
-"French Polynesia",PYF
-"French Southern and Antarctic Lands",ATF
-"Gabon",GAB
+Bosnia and Herzegovina,BIH
+Botswana,BWA
+Bouvet Island,BVT
+Brazil,BRA
+British Indian Ocean Territory,IOT
+Brunei,BRN
+Bulgaria,BGR
+Burkina Faso,BFA
+Burma,MMR
+Burundi,BDI
+Cabo Verde,CPV
+Cambodia,KHM
+Cameroon,CMR
+Canada,CAN
+Cayman Islands,CYM
+Central African Republic,CAF
+Chad,TCD
+Chile,CHL
+China,CHN
+Christmas Island,CXR
+Clipperton Island,CPT
+Cocos (Keeling) Islands,CCK
+Colombia,COL
+Comoros,COM
+Congo (Brazzaville),COG
+Congo (Kinshasa),COD
+Cook Islands,COK
+Coral Sea Islands,XCS
+Costa Rica,CRI
+Côte d’Ivoire,CIV
+Croatia,HRV
+Cuba,CUB
+Curaçao,CUW
+Cyprus,CYP
+Czech Republic,CZE
+Denmark,DNK
+Dhekelia,XXD
+Diego Garcia,DGA
+Djibouti,DJI
+Dominica,DMA
+Dominican Republic,DOM
+Ecuador,ECU
+Egypt,EGY
+El Salvador,SLV
+Entity 1,XAZ
+Entity 2,XCR
+Entity 3,XCY
+Entity 4,XKM
+Entity 5,XKN
+Entity 6,AX3
+Equatorial Guinea,GNQ
+Eritrea,ERI
+Estonia,EST
+Ethiopia,ETH
+Europa Island,XEU
+Falkland Islands (Islas Malvinas),FLK
+Faroe Islands,FRO
+Fiji,FJI
+Finland,FIN
+France,FRA
+French Guiana,GUF
+French Polynesia,PYF
+French Southern and Antarctic Lands,ATF
+Gabon,GAB
 "Gambia, The",GMB
-"Gaza Strip",XGZ
-"Georgia",GEO
-"Germany",DEU
-"Ghana",GHA
-"Gibraltar",GIB
-"Glorioso Islands",XGL
-"Greece",GRC
-"Greenland",GRL
-"Grenada",GRD
-"Guadeloupe",GLP
-"Guam",GUM
-"Guantanamo Bay Naval Base",AX2
-"Guatemala",GTM
-"Guernsey",GGY
-"Guinea",GIN
-"Guinea-Bissau",GNB
-"Guyana",GUY
-"Haiti",HTI
-"Heard Island and Mcdonald Islands",HMD
-"Honduras",HND
-"Hong Kong",HKG
-"Howland Island",XHO
-"Hungary",HUN
-"Iceland",ISL
-"India",IND
-"Indonesia",IDN
-"Iran",IRN
-"Iraq",IRQ
-"Ireland",IRL
-"Isle Of Man",IMN
-"Israel",ISR
-"Italy",ITA
-"Jamaica",JAM
-"Jan Mayen",XJM
-"Japan",JPN
-"Jarvis Island",XJV
-"Jersey",JEY
-"Johnston Atoll",XJA
-"Jordan",JOR
-"Juan De Nova Island",XJN
-"Kazakhstan",KAZ
-"Kenya",KEN
-"Kingman Reef",XKR
-"Kiribati",KIR
+Gaza Strip,XGZ
+Georgia,GEO
+Germany,DEU
+Ghana,GHA
+Gibraltar,GIB
+Glorioso Islands,XGL
+Greece,GRC
+Greenland,GRL
+Grenada,GRD
+Guadeloupe,GLP
+Guam,GUM
+Guantanamo Bay Naval Base,AX2
+Guatemala,GTM
+Guernsey,GGY
+Guinea,GIN
+Guinea-Bissau,GNB
+Guyana,GUY
+Haiti,HTI
+Heard Island and Mcdonald Islands,HMD
+Honduras,HND
+Hong Kong,HKG
+Howland Island,XHO
+Hungary,HUN
+Iceland,ISL
+India,IND
+Indonesia,IDN
+Iran,IRN
+Iraq,IRQ
+Ireland,IRL
+Isle Of Man,IMN
+Israel,ISR
+Italy,ITA
+Jamaica,JAM
+Jan Mayen,XJM
+Japan,JPN
+Jarvis Island,XJV
+Jersey,JEY
+Johnston Atoll,XJA
+Jordan,JOR
+Juan De Nova Island,XJN
+Kazakhstan,KAZ
+Kenya,KEN
+Kingman Reef,XKR
+Kiribati,KIR
 "Korea, North",PRK
 "Korea, South",KOR
-"Kosovo",XKS
-"Kuwait",KWT
-"Kyrgyzstan",KGZ
-"Laos",LAO
-"Latvia",LVA
-"Lebanon",LBN
-"Lesotho",LSO
-"Liberia",LBR
-"Libya",LBY
-"Liechtenstein",LIE
-"Lithuania",LTU
-"Luxembourg",LUX
-"Macau",MAC
-"Macedonia",MKD
-"Madagascar",MDG
-"Malawi",MWI
-"Malaysia",MYS
-"Maldives",MDV
-"Mali",MLI
-"Malta",MLT
-"Marshall Islands",MHL
-"Martinique",MTQ
-"Mauritania",MRT
-"Mauritius",MUS
-"Mayotte",MYT
-"Mexico",MEX
+Kosovo,XKS
+Kuwait,KWT
+Kyrgyzstan,KGZ
+Laos,LAO
+Latvia,LVA
+Lebanon,LBN
+Lesotho,LSO
+Liberia,LBR
+Libya,LBY
+Liechtenstein,LIE
+Lithuania,LTU
+Luxembourg,LUX
+Macau,MAC
+Macedonia,MKD
+Madagascar,MDG
+Malawi,MWI
+Malaysia,MYS
+Maldives,MDV
+Mali,MLI
+Malta,MLT
+Marshall Islands,MHL
+Martinique,MTQ
+Mauritania,MRT
+Mauritius,MUS
+Mayotte,MYT
+Mexico,MEX
 "Micronesia, Federated States Of",FSM
-"Midway Islands",XMW
-"Moldova",MDA
-"Monaco",MCO
-"Mongolia",MNG
-"Montenegro",MNE
-"Montserrat",MSR
-"Morocco",MAR
-"Mozambique",MOZ
-"Namibia",NAM
-"Nauru",NRU
-"Navassa Island",XNV
-"Nepal",NPL
-"Netherlands",NLD
-"New Caledonia",NCL
-"New Zealand",NZL
-"Nicaragua",NIC
-"Niger",NER
-"Nigeria",NGA
-"Niue",NIU
-"Norfolk Island",NFK
-"Northern Mariana Islands",MNP
-"Norway",NOR
-"Oman",OMN
-"Pakistan",PAK
-"Palau",PLW
-"Palmyra Atoll",XPL
-"Panama",PAN
-"Papua New Guinea",PNG
-"Paracel Islands",XPR
-"Paraguay",PRY
-"Peru",PER
-"Philippines",PHL
-"Pitcairn Islands",PCN
-"Poland",POL
-"Portugal",PRT
-"Puerto Rico",PRI
-"Qatar",QAT
-"Reunion",REU
-"Romania",ROU
-"Russia",RUS
-"Rwanda",RWA
-"Saint Barthelemy",BLM
+Midway Islands,XMW
+Moldova,MDA
+Monaco,MCO
+Mongolia,MNG
+Montenegro,MNE
+Montserrat,MSR
+Morocco,MAR
+Mozambique,MOZ
+Namibia,NAM
+Nauru,NRU
+Navassa Island,XNV
+Nepal,NPL
+Netherlands,NLD
+New Caledonia,NCL
+New Zealand,NZL
+Nicaragua,NIC
+Niger,NER
+Nigeria,NGA
+Niue,NIU
+Norfolk Island,NFK
+Northern Mariana Islands,MNP
+Norway,NOR
+Oman,OMN
+Pakistan,PAK
+Palau,PLW
+Palmyra Atoll,XPL
+Panama,PAN
+Papua New Guinea,PNG
+Paracel Islands,XPR
+Paraguay,PRY
+Peru,PER
+Philippines,PHL
+Pitcairn Islands,PCN
+Poland,POL
+Portugal,PRT
+Puerto Rico,PRI
+Qatar,QAT
+Reunion,REU
+Romania,ROU
+Russia,RUS
+Rwanda,RWA
+Saint Barthelemy,BLM
 "Saint Helena, Ascension, and Tristan Da Cunha",SHN
-"Saint Kitts and Nevis",KNA
-"Saint Lucia",LCA
-"Saint Martin",MAF
-"Saint Pierre and Miquelon",SPM
-"Saint Vincent and The Grenadines",VCT
-"Samoa",WSM
-"San Marino",SMR
-"Sao Tome and Principe",STP
-"Saudi Arabia",SAU
-"Senegal",SEN
-"Serbia",SRB
-"Seychelles",SYC
-"Sierra Leone",SLE
-"Singapore",SGP
-"Sint Maarten",SXM
-"Slovakia",SVK
-"Slovenia",SVN
-"Solomon Islands",SLB
-"Somalia",SOM
-"South Africa",ZAF
-"South Georgia and South Sandwich Islands",SGS
-"South Sudan",SSD
-"Spain",ESP
-"Spratly Islands",XSP
-"Sri Lanka",LKA
-"Sudan",SDN
-"Suriname",SUR
-"Svalbard",XSV
-"Swaziland",SWZ
-"Sweden",SWE
-"Switzerland",CHE
-"Syria",SYR
-"Taiwan",TWN
-"Tajikistan",TJK
-"Tanzania",TZA
-"Thailand",THA
-"Timor-Leste",TLS
-"Togo",TGO
-"Tokelau",TKL
-"Tonga",TON
-"Trinidad and Tobago",TTO
-"Tromelin Island",XTR
-"Tunisia",TUN
-"Turkey",TUR
-"Turkmenistan",TKM
-"Turks and Caicos Islands",TCA
-"Tuvalu",TUV
-"Uganda",UGA
-"Ukraine",UKR
-"United Arab Emirates",ARE
-"United Kingdom",GBR
-"United States",USA
-"Unknown",AX1
-"Uruguay",URY
-"Uzbekistan",UZB
-"Vanuatu",VUT
-"Vatican City",VAT
-"Venezuela",VEN
-"Vietnam",VNM
+Saint Kitts and Nevis,KNA
+Saint Lucia,LCA
+Saint Martin,MAF
+Saint Pierre and Miquelon,SPM
+Saint Vincent and The Grenadines,VCT
+Samoa,WSM
+San Marino,SMR
+Sao Tome and Principe,STP
+Saudi Arabia,SAU
+Senegal,SEN
+Serbia,SRB
+Seychelles,SYC
+Sierra Leone,SLE
+Singapore,SGP
+Sint Maarten,SXM
+Slovakia,SVK
+Slovenia,SVN
+Solomon Islands,SLB
+Somalia,SOM
+South Africa,ZAF
+South Georgia and South Sandwich Islands,SGS
+South Sudan,SSD
+Spain,ESP
+Spratly Islands,XSP
+Sri Lanka,LKA
+Sudan,SDN
+Suriname,SUR
+Svalbard,XSV
+Swaziland,SWZ
+Sweden,SWE
+Switzerland,CHE
+Syria,SYR
+Taiwan,TWN
+Tajikistan,TJK
+Tanzania,TZA
+Thailand,THA
+Timor-Leste,TLS
+Togo,TGO
+Tokelau,TKL
+Tonga,TON
+Trinidad and Tobago,TTO
+Tromelin Island,XTR
+Tunisia,TUN
+Turkey,TUR
+Turkmenistan,TKM
+Turks and Caicos Islands,TCA
+Tuvalu,TUV
+Uganda,UGA
+Ukraine,UKR
+United Arab Emirates,ARE
+United Kingdom,GBR
+United States,USA
+Unknown,AX1
+Uruguay,URY
+Uzbekistan,UZB
+Vanuatu,VUT
+Vatican City,VAT
+Venezuela,VEN
+Vietnam,VNM
 "Virgin Islands, British",VGB
 "Virgin Islands, U.S.",VIR
-"Wake Island",XWK
-"Wallis and Futuna",WLF
-"West Bank",XWB
-"Western Sahara",ESH
-"Yemen",YEM
-"Zambia",ZMB
-"Zimbabwe",ZWE
+Wake Island,XWK
+Wallis and Futuna,WLF
+West Bank,XWB
+Western Sahara,ESH
+Yemen,YEM
+Zambia,ZMB
+Zimbabwe,ZWE

--- a/samples/name_domains_values/Coded_Domain_Credibility.csv
+++ b/samples/name_domains_values/Coded_Domain_Credibility.csv
@@ -1,7 +1,7 @@
 Name,Value
-"Confirmed by Other Sources",1
-"Probably True",2
-"Possibly True",3
-"Doubtfully True",4
-"Improbable",5
-"Truth Cannot Be Judged",6
+Confirmed by Other Sources,1
+Probably True,2
+Possibly True,3
+Doubtfully True,4
+Improbable,5
+Truth Cannot Be Judged,6

--- a/samples/name_domains_values/Coded_Domain_Reliability.csv
+++ b/samples/name_domains_values/Coded_Domain_Reliability.csv
@@ -1,7 +1,7 @@
 Name,Value
-"Completely Reliable",A
-"Usually Reliable",B
-"Fairly Reliable",C
-"Not Usually Reliable",D
-"Unreliable",E
-"Reliability Cannot Be Judged",F
+Completely Reliable,A
+Usually Reliable,B
+Fairly Reliable,C
+Not Usually Reliable,D
+Unreliable,E
+Reliability Cannot Be Judged,F

--- a/samples/name_domains_values/Coded_Domain_SIGINTMobility.csv
+++ b/samples/name_domains_values/Coded_Domain_SIGINTMobility.csv
@@ -1,4 +1,4 @@
 Name,Value
-"Mobile",M
-"Static",S
-"Uncertain",U
+Mobile,M
+Static,S
+Uncertain,U

--- a/samples/name_domains_values/Coded_Domain_SpeedUnits.csv
+++ b/samples/name_domains_values/Coded_Domain_SpeedUnits.csv
@@ -1,5 +1,5 @@
 Name,Value
-"Kilometers Per Hour",KPH
-"Meters Per Second",MPS
-"Nautical Miles Per Hour (Knots)",KTS
-"Statute Miles Per Hour",MPH
+Kilometers Per Hour,KPH
+Meters Per Second,MPS
+Nautical Miles Per Hour (Knots),KTS
+Statute Miles Per Hour,MPH

--- a/source/JointMilitarySymbologyLibraryCS/ConfigHelper.cs
+++ b/source/JointMilitarySymbologyLibraryCS/ConfigHelper.cs
@@ -387,7 +387,12 @@ namespace JointMilitarySymbologyLibrary
 
             // Uses overrides in the jmsml configuration file to deliver custom output.
 
-            string result = "\"" + value.Label + "\"" + "," + value.LabelAlias;
+            string result;
+            
+            if(value.Label.Contains(','))
+                result = "\"" + value.Label + "\"" + "," + value.LabelAlias;
+            else
+                result = value.Label + "," + value.LabelAlias;
 
             foreach (JMSMLConfigETLConfigAmplifierValue v in _etlConfig.AmplifierValues)
             {


### PR DESCRIPTION
Only the specific Amplifier Names with embedded commas (because the
standard says the comma is required) are quoted in exported CSV files.