### PR TITLE
Assasination -> Assassination spelling correction

### DIFF
--- a/instance/jmsml_D_Activity.xml
+++ b/instance/jmsml_D_Activity.xml
@@ -978,7 +978,7 @@
         <DigitTwo>0</DigitTwo>
       </ModifierCode>
     </Modifier>
-    <Modifier ID="ASSASSINATION_MOD" Label="Assassination" LabelAlias="Assasination (Activities)" Graphic="40011.svg" Category="Crime">
+    <Modifier ID="ASSASSINATION_MOD" Label="Assassination" LabelAlias="Assassination (Activities)" Graphic="40011.svg" Category="Crime">
       <ModifierCode>
         <DigitOne>0</DigitOne>
         <DigitTwo>1</DigitTwo>


### PR DESCRIPTION
It is spelled correctly in the label, but not the alias (& the alias is what is used in our domains)