### PR TITLE
allow jmsml instances without Legacy symbols

### DIFF
--- a/schema/base.xsd
+++ b/schema/base.xsd
@@ -150,7 +150,7 @@
               <xs:element name="StandardIdentityGroup" minOccurs="1" maxOccurs="4">
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element name="LegacyStandardIdentityCode" type="LegacyLetterCodeType" minOccurs="1" maxOccurs="unbounded"/>
+                    <xs:element name="LegacyStandardIdentityCode" type="LegacyLetterCodeType" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="StandardIdentityGroupCode" type="SingleDigitType"/>
                   </xs:sequence>
                   <xs:attributeGroup ref="IdentifierAttributeGroup"/>


### PR DESCRIPTION
Hello,

I tried to create a JMSML instance without Legacy symbols but this fails because the base.xsd request at least one LegacyStandardIdentityCode for StandardIdentityGroup. Could we set this to "0"?

Thanks and BR Andreas