### PR TITLE
Fix 'hierarchical' typos

### DIFF
--- a/instance/Activity.xml
+++ b/instance/Activity.xml
@@ -14,7 +14,7 @@
         <DigitTwo>0</DigitTwo>
       </EntityCode>
     </Entity>
-    <Entity ID="INCIDENT" Label="Incident" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="INCIDENT" Label="Incident" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>1</DigitTwo>
@@ -306,7 +306,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="OPERATION" Label="Operation" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="OPERATION" Label="Operation" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>3</DigitTwo>
@@ -338,7 +338,7 @@
             <DigitTwo>3</DigitTwo>
           </EntityTypeCode>
         </EntityType>
-        <EntityType ID="RECRUITMENT" Label="Recruitment" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+        <EntityType ID="RECRUITMENT" Label="Recruitment" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
           <EntityTypeCode>
             <DigitOne>0</DigitOne>
             <DigitTwo>4</DigitTwo>
@@ -678,7 +678,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="HAZARD_MATERIALS" Label="Hazard Materials" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="HAZARD_MATERIALS" Label="Hazard Materials" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>5</DigitTwo>
@@ -950,7 +950,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="INDIVIDUAL" Label="Individual" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="INDIVIDUAL" Label="Individual" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>8</DigitTwo>

--- a/instance/Air.xml
+++ b/instance/Air.xml
@@ -12,7 +12,7 @@
         <DigitTwo>0</DigitTwo>
       </EntityCode>
     </Entity>
-    <Entity ID="MILITARY" Label="Military" LabelAlias="Military (Air)" Remarks="Reserved for hiearchical purposes." Graphic="01110000.svg">
+    <Entity ID="MILITARY" Label="Military" LabelAlias="Military (Air)" Remarks="Reserved for hierarchical purposes." Graphic="01110000.svg">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>1</DigitTwo>
@@ -256,7 +256,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="CIVILIAN" Label="Civilian" LabelAlias="Civilian (Air)" Remarks="Reserved for hiearchical purposes." Graphic="01120000.svg">
+    <Entity ID="CIVILIAN" Label="Civilian" LabelAlias="Civilian (Air)" Remarks="Reserved for hierarchical purposes." Graphic="01120000.svg">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>2</DigitTwo>
@@ -300,7 +300,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="WEAPON" Label="Weapon" LabelAlias="Weapon (Air)" Remarks="Reserved for hiearchical purposes." Graphic="01130000.svg">
+    <Entity ID="WEAPON" Label="Weapon" LabelAlias="Weapon (Air)" Remarks="Reserved for hierarchical purposes." Graphic="01130000.svg">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>3</DigitTwo>

--- a/instance/Land_Installation.xml
+++ b/instance/Land_Installation.xml
@@ -263,7 +263,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="INFRASTRUCTURE" Label="Infrastructure" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="INFRASTRUCTURE" Label="Infrastructure" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>2</DigitTwo>

--- a/instance/Land_Unit.xml
+++ b/instance/Land_Unit.xml
@@ -134,7 +134,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="MOVEMENT_AND_MANEUVER" Label="Movement and Maneuver" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="MOVEMENT_AND_MANEUVER" Label="Movement and Maneuver" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>2</DigitTwo>
@@ -384,7 +384,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="FIRES" Label="Fires" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="FIRES" Label="Fires" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>3</DigitTwo>
@@ -494,7 +494,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="PROTECTION" Label="Protection" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="PROTECTION" Label="Protection" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>4</DigitTwo>
@@ -694,7 +694,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="INTELLIGENCE" Label="Intelligence" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="INTELLIGENCE" Label="Intelligence" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>5</DigitTwo>
@@ -1108,7 +1108,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="NAVAL" Label="Naval" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="NAVAL" Label="Naval" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>7</DigitTwo>
@@ -1122,7 +1122,7 @@
         </EntityType>
       </EntityTypes>
     </Entity>
-    <Entity ID="NAMED_HEADQUARTERS" Label="Named Headquarters" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+    <Entity ID="NAMED_HEADQUARTERS" Label="Named Headquarters" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
       <EntityCode>
         <DigitOne>1</DigitOne>
         <DigitTwo>8</DigitTwo>

--- a/instance/Meteorological_Space.xml
+++ b/instance/Meteorological_Space.xml
@@ -12,7 +12,7 @@
         <DigitTwo>0</DigitTwo>
       </EntityCode>
     </Entity>
-		<Entity ID="SPACE" Label="Space" Remarks="Reserved for hiearchical purposes." Icon="NA" GeometryType="NA">
+		<Entity ID="SPACE" Label="Space" Remarks="Reserved for hierarchical purposes." Icon="NA" GeometryType="NA">
 			<EntityCode>
 				<DigitOne>1</DigitOne>
 				<DigitTwo>1</DigitTwo>


### PR DESCRIPTION
@yemikudaisi found a few typos in my symbolology explorer (https://github.com/kjellmf/military-symbology-explorer/issues/46) The typos originate from JMSML, so it is better to fix them there. 