### PR TITLE
--export-png does not work anymore, with --export-type and --export-f…

### DIFF
--- a/source/utilities/image-conversion-utilities/ConvertTree-SVGtoPNG-128.bat
+++ b/source/utilities/image-conversion-utilities/ConvertTree-SVGtoPNG-128.bat
@@ -102,7 +102,7 @@ echo "Exporting %source_file% ==> %new_file_png%"
 
 :: IMPORTANT: Now actually call the exporter/converter here:
 :: TODO: SET THE DESIRED HEIGHT/WIDTH HERE (currently 64 pixels):
-"%1" "%2" --export-width=128 --export-height=128 --export-png="%new_file_png%" 
+"%1" "%2" --export-width=128 --export-height=128 --export-type=PNG --export-filename="%new_file_png%"
 
 endlocal & goto :EOF
 

--- a/source/utilities/image-conversion-utilities/ConvertTree-SVGtoPNG-256.bat
+++ b/source/utilities/image-conversion-utilities/ConvertTree-SVGtoPNG-256.bat
@@ -102,7 +102,7 @@ echo "Exporting %source_file% ==> %new_file_png%"
 
 :: IMPORTANT: Now actually call the exporter/converter here:
 :: TODO: SET THE DESIRED HEIGHT/WIDTH HERE (currently 64 pixels):
-"%1" "%2" --export-width=256 --export-height=256 --export-png="%new_file_png%" 
+"%1" "%2" --export-width=256 --export-height=256 --export-type=PNG --export-filename="%new_file_png%"
 
 endlocal & goto :EOF
 


### PR DESCRIPTION
--export-png is marked ad deprecated, but doesn't work at all anymore. I used the Inkscape manual (https://inkscape.org/doc/inkscape-man.html) to determine the new arguments. The new arguments I used are --export-type and --export-filename.